### PR TITLE
to fix “duplicate interface declaration” error

### DIFF
--- a/Classes/POPAnimatableProperty+Masonry.h
+++ b/Classes/POPAnimatableProperty+Masonry.h
@@ -4,7 +4,7 @@
 //  Created by Mikkel Selsøe Sørensen on 30/05/14.
 //
 
-#import "POPAnimatableProperty.h"
+#import "pop/POPAnimatableProperty.h"
 
 @interface POPAnimatableProperty (Masonry)
 


### PR DESCRIPTION
to fix “duplicate interface declaration” error of POPAnimatableProperty under
XCode7
swift2
cocoapods 0.39.0
